### PR TITLE
👷 Update server to new version 

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.316
+FROM jenkins/jenkins:2.336
 
 # Root is required to modify uid
 USER root


### PR DESCRIPTION
The current version of Jenkins, 2.316  is showing lots of warnings. So updated it to more recent version 