### PR TITLE
🐛  Fix for new worker image

### DIFF
--- a/.github/workflows/worker_build.yml
+++ b/.github/workflows/worker_build.yml
@@ -5,6 +5,8 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - "*"  
 
 jobs:
   # define job to build and publish docker image

--- a/.github/workflows/worker_build.yml
+++ b/.github/workflows/worker_build.yml
@@ -41,5 +41,5 @@ jobs:
           context: ./worker
           # Note: tags has to be all lower-case
           tags: |
-              satel/jenkins-worker:${{env.RELEASE_VERSION}}
+              satel/jenkins-worker:testfeb4
           push: true

--- a/.github/workflows/worker_build.yml
+++ b/.github/workflows/worker_build.yml
@@ -39,5 +39,5 @@ jobs:
           context: ./worker
           # Note: tags has to be all lower-case
           tags: |
-              satel/jenkins-worker:testfeb4
+              satel/jenkins-worker:${{env.RELEASE_VERSION}}
           push: true

--- a/.github/workflows/worker_build.yml
+++ b/.github/workflows/worker_build.yml
@@ -5,8 +5,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - "**"  
 
 jobs:
   # define job to build and publish docker image

--- a/.github/workflows/worker_build.yml
+++ b/.github/workflows/worker_build.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - "*"
     branches:
-      - "*"  
+      - "**"  
 
 jobs:
   # define job to build and publish docker image

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -8,6 +8,10 @@ RUN groupadd -g 995 docker && usermod -a -G docker jenkins
 
 # Install the latest Docker CE binaries
 RUN apt-get update\
+    && curl -L -O https://github.com/docker/docker-credential-helpers/releases/download/v0.6.4/docker-credential-pass-v0.6.4-amd64.tar.gz
+    && tar zxvf docker-credential-pass-v0.6.4-amd64.tar.gz\
+    && chmod +x docker-credential-pass\
+    && ./docker-credential-pass version 0.6.4\
     && apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common\
     && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg > /tmp/dkey\
     && apt-key add /tmp/dkey\
@@ -16,8 +20,7 @@ RUN apt-get update\
     && apt-get -y install docker-ce python3-pip\
     && apt-get -y install docker-compose\
     && curl -L https://github.com/docker/machine/releases/download/v0.14.0/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine\
-    && chmod +x /usr/local/bin/docker-machine\
-    && apt-get install pass
+    && chmod +x /usr/local/bin/docker-machine
 
 # restore ENTRYPOINT to startup as jenkins user
 USER jenkins

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jnlp-slave:4.9-1
+FROM jenkins/slave:4.9-1
 
 # Root is required to modify uid
 USER root

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jnlp-slave:4.7-1
+FROM jenkins/jnlp-slave:4.9-1
 
 # Root is required to modify uid
 USER root
@@ -17,6 +17,7 @@ RUN apt-get update\
     && apt-get -y install docker-compose\
     && curl -L https://github.com/docker/machine/releases/download/v0.14.0/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine\
     && chmod +x /usr/local/bin/docker-machine
+    && apt-get -y gnupg2 pass
 
 # restore ENTRYPOINT to startup as jenkins user
 USER jenkins

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/slave:4.9-1
+FROM jenkins/jnlp-slave:4.7-1
 
 # Root is required to modify uid
 USER root

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update\
     && apt-get -y install docker-compose\
     && curl -L https://github.com/docker/machine/releases/download/v0.14.0/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine\
     && chmod +x /usr/local/bin/docker-machine\
-    && apt-get -y gnupg2 pass
+    && apt-get install pass
 
 # restore ENTRYPOINT to startup as jenkins user
 USER jenkins

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -8,10 +8,7 @@ RUN groupadd -g 995 docker && usermod -a -G docker jenkins
 
 # Install the latest Docker CE binaries
 RUN apt-get update\
-    && curl -L -O https://github.com/docker/docker-credential-helpers/releases/download/v0.6.4/docker-credential-pass-v0.6.4-amd64.tar.gz
-    && tar zxvf docker-credential-pass-v0.6.4-amd64.tar.gz\
-    && chmod +x docker-credential-pass\
-    && ./docker-credential-pass version 0.6.4\
+    && apt-get -y install gnupg2 pass\
     && apt-get -y install apt-transport-https ca-certificates curl gnupg2 software-properties-common\
     && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg > /tmp/dkey\
     && apt-key add /tmp/dkey\
@@ -21,6 +18,7 @@ RUN apt-get update\
     && apt-get -y install docker-compose\
     && curl -L https://github.com/docker/machine/releases/download/v0.14.0/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine\
     && chmod +x /usr/local/bin/docker-machine
+    
 
 # restore ENTRYPOINT to startup as jenkins user
 USER jenkins

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update\
     && apt-get -y install docker-ce python3-pip\
     && apt-get -y install docker-compose\
     && curl -L https://github.com/docker/machine/releases/download/v0.14.0/docker-machine-`uname -s`-`uname -m` >/usr/local/bin/docker-machine\
-    && chmod +x /usr/local/bin/docker-machine
+    && chmod +x /usr/local/bin/docker-machine\
     && apt-get -y gnupg2 pass
 
 # restore ENTRYPOINT to startup as jenkins user


### PR DESCRIPTION
With the new worker image we were getting an erorr on docker login 
`Error saving credentials: error storing credentials - err: exit status 1, out: Cannot autolaunch D-Bus without X11 $DISPLAY`
This PR is a fix for that 
Closes: https://github.com/SatelCreative/DevOps-IT/issues/129
