### PR TITLE
👷 Feature/spring maintenance 2022

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.343
+FROM jenkins/jenkins:2.350
 
 # Root is required to modify uid
 USER root

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.350
+FROM jenkins/jenkins:2.356
 
 # Root is required to modify uid
 USER root

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jnlp-slave:4.9-1
+FROM jenkins/inbound-agent:4.10-3
 
 # Root is required to modify uid
 USER root


### PR DESCRIPTION
- Update server image from `jenkins/jenkins:2.343` -> `jenkins/jenkins:2.356`
- Update worker image from  `jenkins/jnlp-slave:4.9-1` -> `jenkins/inbound-agent:4.10-3`
Please note that `jenkins/jnlp-slave` is now depreciated: [Source ](https://hub.docker.com/r/jenkins/inbound-agent)